### PR TITLE
Add Property to disable extension to allways open docuement after rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
 					"type": "string",
 					"default": "",
 					"description": "pandoc .rst output option template that you would like to use"
+				},
+				"pandoc.render.openViewer": {
+					"type":"boolean",
+					"default": "true",
+					"description": "specify if the extension will open the rendered document in it's default viewer"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,19 @@ function getPandocOptions(quickPickLabel) {
     return pandocOptions;
 }
 
+function openDocument(outFile: string) {
+    switch (process.platform) {
+        case 'darwin':
+            exec('open ' + outFile);
+            break;
+        case 'linux':
+            exec('xdg-open ' + outFile);
+            break;
+        default:
+            exec(outFile);
+    }
+}
+
 export function activate(context: vscode.ExtensionContext) {
 
     console.log('Congratulations, your extension "vscode-pandoc" is now active!');
@@ -108,17 +121,13 @@ export function activate(context: vscode.ExtensionContext) {
                     vscode.window.showErrorMessage('exec error: ' + error);
                     pandocOutputChannel.append('exec error: ' + error + '\n');
                 } else {
-                    setStatusBarText('Launching', qpSelection.label);
-                    switch (process.platform) {
-                        case 'darwin':
-                            exec('open ' + outFile);
-                            break;
-                        case 'linux':
-                            exec('xdg-open ' + outFile);
-                            break;
-                        default:
-                            exec(outFile);
+                    var openViewer = vscode.workspace.getConfiguration('pandoc').get('render.openViewer');
+
+                    if (openViewer) {
+                        setStatusBarText('Launching', qpSelection.label);
+                        openDocument(outFile);
                     }
+
                 }
             });
         });


### PR DESCRIPTION
Hi,

I've come around this extension shortly and found it usefull. 
The only annoying thing is that (in my case) the pdf file always get opened in an external viewer automaticlly. 
I use a pdf viewer inside of vscode so I don't need the pdf file opened in an external viewer.

This pull request fix this behavior through adding a new property which lets the user decide if the document will be opened or not. 