### PR TITLE
Pandoc location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ example:
 "pandoc.docxOptString": "",
 
 // pandoc .html output option template that you would like to use
-"pandoc.htmlOptString": ""
+"pandoc.htmlOptString": "",
+
+// path to the pandoc executable. By default gets from PATH variable
+"pandoc.executable": ""
 ```
 
 * if necessary to set options for each output format.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,12 @@
             "type": "string",
             "default": "",
             "description": "pandoc .html output option template that you would like to use"
-          }
+					},
+					"pandoc.executable": {
+							"type": "string",
+							"default": "",
+							"description": "pandoc executable location if not specified in the PATH variable"
+					}
        }
      },
      "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,16 @@ function getPandocOptions(quickPickLabel) {
     return pandocOptions;
 }
 
+function getPandocExecutablePath() {
+    // By default pandoc executable should be in the PATH environment variable.
+    var pandocExecutablePath = 'pandoc';
+    if (vscode.workspace.getConfiguration('pandoc').has('executable') && 
+        vscode.workspace.getConfiguration('pandoc').get('executable') !== '') {
+        pandocExecutablePath = vscode.workspace.getConfiguration('pandoc').get('executable');
+    }
+    return pandocExecutablePath;
+}
+
 export function activate(context: vscode.ExtensionContext) {
 
 	console.log('Congratulations, your extension "vscode-pandoc" is now active!'); 
@@ -65,8 +75,11 @@ export function activate(context: vscode.ExtensionContext) {
             console.log('debug: inFile = ' + outFile);
             console.log('debug: pandoc ' + inFile + ' -o ' + outFile + pandocOptions);
             
-            var space = '\x20';            
-            var targetExec = 'pandoc' + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
+            var space = '\x20';
+            var pandocExecutablePath = getPandocExecutablePath();
+            console.log('debug: pandoc executable path = ' + pandocExecutablePath);
+
+            var targetExec = pandocExecutablePath + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
             console.log('debug: exec ' + targetExec);
             
             var child = exec(targetExec, { cwd: filePath }, function(error, stdout, stderr) {


### PR DESCRIPTION
`pandoc.executable` option was added (#2)

Default value for the option is empty string. If  `pandoc.executable` is empty so extension uses default `pandoc` executable. 

In case you want to use specific executable you can speicfy the full path as a value for the option. For example `c:/program files/pandoc/pandoc.exe` for Windows.