### PR TITLE
Add container support using the official pandoc/latex image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ _Thanks to the previous work of [@dfinke](https://github.com/dfinke) on this ext
 
 You need to [**install Pandoc**](http://pandoc.org/installing.html) - a universal document converter.
 
+Alternatively you may set the `useDocker` option to true and it will run Pandoc in a container using the latest official [pandoc/latex](https://hub.docker.com/r/pandoc/latex) image. This could result in a delay the first time it runs, or after an update to the container while it pulls down the new image.
+
 ## Usage
 
 Two ways to run the extension. You need to have a markdown file open.
@@ -62,6 +64,9 @@ example:
 
 // path to the pandoc executable. By default gets from PATH variable
 "pandoc.executable": ""
+
+// enable running pandoc in a docker container
+"pandoc.useDocker": "true"
 ```
 
 * if necessary to set options for each output format.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-pandoc",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
           "type": "boolean",
           "default": "true",
           "description": "specify if the extension will open the rendered document in it's default viewer"
+        },
+        "pandoc.useDocker": {
+          "type": "boolean",
+          "default": "false",
+          "description": "specify if the extension will run pandoc from a docker container"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-pandoc",
   "description": "Renders markdown through pandoc",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publisher": "ChrisChinchilla",
   "icon": "images/logo.png",
   "license": "SEE LICENSE",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,11 +112,13 @@ export function activate(context: vscode.ExtensionContext) {
             console.log('debug: inFile = ' + outFile);
             console.log('debug: pandoc ' + inFile + ' -o ' + outFile + pandocOptions);
             
-            var space = '\x20';
             var pandocExecutablePath = getPandocExecutablePath();
             console.log('debug: pandoc executable path = ' + pandocExecutablePath);
 
-            var targetExec = '"' + pandocExecutablePath + '"' + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
+            var useDocker = vscode.workspace.getConfiguration('pandoc').get('useDocker');
+            var targetExec = useDocker 
+                ? `docker run --rm -v "${filePath}:/data" pandoc/latex:latest "${fileName}" -o "${fileNameOnly}.${qpSelection.label}" ${pandocOptions}`
+                : `"${pandocExecutablePath}" ${inFile} -o ${outFile} ${pandocOptions}`;
             console.log('debug: exec ' + targetExec);
 
             var child = exec(targetExec, { cwd: filePath }, function (error, stdout, stderr) {


### PR DESCRIPTION
Add support for running pandoc in a container using the [latest official pandoc/latex container](https://hub.docker.com/r/pandoc/latex). This includes a new configuration property, `pandoc.useDocker`, which defaults to false so that the original behavior is preserved.