### PR TITLE
Add docker.options support - fixed #32

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off",
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "master"
-    ]
+    "typescript.tsc.autoDetect": "off"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Choose from the list what document type you want to render and press `enter` (yo
 
 ## Releases
 
+* December 1st, 2023
+  * Added pandoc.docker.options and pandoc.docker.image configurations
+  * Existing pandoc.useDocker configuration will be migrated to new configuration
 * June 21st, 2023
   * Package updates
   * Read me updates
@@ -65,10 +68,16 @@ example:
 "pandoc.htmlOptString": "",
 
 // path to the pandoc executable. By default gets from PATH variable
-"pandoc.executable": ""
+"pandoc.executable": "",
 
 // enable running pandoc in a docker container
-"pandoc.useDocker": "true"
+"pandoc.docker.enabled": "true",
+
+// specify the docker options when "pandoc.docker.enabled" is "true"
+"pandoc.docker.options": "",
+
+// specify the docker image when "pandoc.docker.enabled" is "true"
+"pandoc.docker.image": ""
 ```
 
 You can set options for each output format.
@@ -98,3 +107,23 @@ For example, for Japanese documents.
   * `-t html5`: HTML5 output format
 
 For more information please refer to the [Pandoc User's Guide](http://pandoc.org/README.html).
+
+## Docker Options
+
+When running on linux systems (and possibly others) when using the docker, there may be file permission issues with the docker image. This can appear as an error such as the following:
+
+```
+stderr: pandoc: file.html: openFile: permission denied (Permission denied)
+
+exec error: Error: Command failed: docker run --rm -v "/home/user/path:/data"  pandoc/latex:latest "file.md" -o "file.html"
+pandoc: file.html: openFile: permission denied (Permission denied)
+```
+
+This may occur due to the file/directory permissions being incorrect. To allow this to function, you can specify the docker options to set the uid/gid using the following:
+
+```json
+  "pandoc.docker.options": "--user $(id -u):$(id -g)"
+```
+
+If needed, you can also change the default pandoc docker image using the `pandoc.docker.image` configuration setting.
+

--- a/package.json
+++ b/package.json
@@ -85,7 +85,24 @@
         "pandoc.useDocker": {
           "type": "boolean",
           "default": false,
+          "description": "specify if the extension will run pandoc from a docker container",
+          "markdownDeprecationMessage": "**Deprecated**: Please use `#pandoc.docker.enabled#` instead.",
+          "deprecationMessage": "Deprecated: Please use pandoc.docker.enabled instead."
+        },
+        "pandoc.docker.enabled": {
+          "type": "boolean",
+          "default": false,
           "description": "specify if the extension will run pandoc from a docker container"
+        },
+        "pandoc.docker.options": {
+            "type": "string",
+            "default": "",
+            "description": "specify the docker options to use if \"docker.enabled\" is true"
+        },
+        "pandoc.docker.image": {
+            "type": "string",
+            "default": "pandoc/latex:latest",
+            "description": "specify the docker image to use if \"docker.enabled\" is true"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,23 +100,26 @@ export function activate(context: vscode.ExtensionContext) {
 
             var pandocExecutablePath = getPandocExecutablePath();
             var pandocConfigurations = vscode.workspace.getConfiguration('pandoc')
-            var deprecatedUseDocker = pandocConfigurations.inspect('useDocker')?.globalValue ?? false
-            if (deprecatedUseDocker !== undefined) {
+
+            var deprecatedUseDockerGlobal = pandocConfigurations.inspect('useDocker')?.globalValue ?? undefined
+            if (deprecatedUseDockerGlobal !== undefined) {
                 pandocOutputChannel.append('migrating global configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
                 vscode.window.showWarningMessage('pandoc: found deprecated value in global configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
-                pandocConfigurations.update('docker.enabled', deprecatedUseDocker, vscode.ConfigurationTarget.Global);
+                pandocConfigurations.update('docker.enabled', deprecatedUseDockerGlobal, vscode.ConfigurationTarget.Global);
                 pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.Global);
             }
-            if (deprecatedUseDocker !== undefined) {
+            var deprecatedUseDockerWorkspace = pandocConfigurations.inspect('useDocker')?.workspaceValue ?? undefined
+            if (deprecatedUseDockerWorkspace !== undefined) {
                 pandocOutputChannel.append('migrating workspace configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
                 vscode.window.showWarningMessage('pandoc: found deprecated value in workspace configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
-                pandocConfigurations.update('docker.enabled', deprecatedUseDocker, vscode.ConfigurationTarget.Workspace);
+                pandocConfigurations.update('docker.enabled', deprecatedUseDockerWorkspace, vscode.ConfigurationTarget.Workspace);
                 pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.Workspace);
             }
-            if (deprecatedUseDocker !== undefined) {
+            var deprecatedUseDockerFolder = pandocConfigurations.inspect('useDocker')?.workspaceFolderValue ?? undefined
+            if (deprecatedUseDockerFolder !== undefined) {
                 pandocOutputChannel.append('migrating folder configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
                 vscode.window.showWarningMessage('pandoc: found deprecated value in folder configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
-                pandocConfigurations.update('docker.enabled', deprecatedUseDocker, vscode.ConfigurationTarget.WorkspaceFolder);
+                pandocConfigurations.update('docker.enabled', deprecatedUseDockerFolder, vscode.ConfigurationTarget.WorkspaceFolder);
                 pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
             }
             var useDocker = pandocConfigurations.get('docker.enabled');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ function getPandocExecutablePath() {
     // By default pandoc executable should be in the PATH environment variable.
     var pandocExecutablePath ;
     console.log(vscode.workspace.getConfiguration('pandoc').get('executable'));
-    if (vscode.workspace.getConfiguration('pandoc').has('executable') && 
+    if (vscode.workspace.getConfiguration('pandoc').has('executable') &&
         vscode.workspace.getConfiguration('pandoc').get('executable') !== '') {
         pandocExecutablePath = vscode.workspace.getConfiguration('pandoc').get('executable');
     }
@@ -97,12 +97,34 @@ export function activate(context: vscode.ExtensionContext) {
             setStatusBarText('Generating', qpSelection.label);
 
             var pandocOptions = getPandocOptions(qpSelection.label);
-            
-            var pandocExecutablePath = getPandocExecutablePath();
 
-            var useDocker = vscode.workspace.getConfiguration('pandoc').get('useDocker');
-            var targetExec = useDocker 
-                ? `docker run --rm -v "${filePath}:/data" pandoc/latex:latest "${fileName}" -o "${fileNameOnly}.${qpSelection.label}" ${pandocOptions}`
+            var pandocExecutablePath = getPandocExecutablePath();
+            var pandocConfigurations = vscode.workspace.getConfiguration('pandoc')
+            var deprecatedUseDocker = pandocConfigurations.inspect('useDocker')
+            if (deprecatedUseDocker['globalValue'] !== undefined) {
+                pandocOutputChannel.append('migrating global configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
+                vscode.window.showWarningMessage('pandoc: found deprecated value in global configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
+                pandocConfigurations.update('docker.enabled', deprecatedUseDocker['globalValue'], vscode.ConfigurationTarget.Global);
+                pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.Global);
+            }
+            if (deprecatedUseDocker['workspaceValue'] !== undefined) {
+                pandocOutputChannel.append('migrating workspace configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
+                vscode.window.showWarningMessage('pandoc: found deprecated value in workspace configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
+                pandocConfigurations.update('docker.enabled', deprecatedUseDocker['workspaceValue'], vscode.ConfigurationTarget.Workspace);
+                pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.Workspace);
+            }
+            if (deprecatedUseDocker['workspaceFolderValue'] !== undefined) {
+                pandocOutputChannel.append('migrating folder configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
+                vscode.window.showWarningMessage('pandoc: found deprecated value in folder configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
+                pandocConfigurations.update('docker.enabled', deprecatedUseDocker['workspaceFolderValue'], vscode.ConfigurationTarget.WorkspaceFolder);
+                pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+            }
+            var useDocker = pandocConfigurations.get('docker.enabled');
+            var dockerOptions = pandocConfigurations.get('docker.options');
+            var dockerImage = pandocConfigurations.get('docker.image');
+
+            var targetExec = useDocker
+                ? `docker run --rm -v "${filePath}:/data" ${dockerOptions} ${dockerImage} "${fileName}" -o "${fileNameOnly}.${qpSelection.label}" ${pandocOptions}`
                 : `"${pandocExecutablePath}" ${inFile} -o ${outFile} ${pandocOptions}`;
 
             var child = exec(targetExec, { cwd: filePath }, function (error, stdout, stderr) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,23 +100,23 @@ export function activate(context: vscode.ExtensionContext) {
 
             var pandocExecutablePath = getPandocExecutablePath();
             var pandocConfigurations = vscode.workspace.getConfiguration('pandoc')
-            var deprecatedUseDocker = pandocConfigurations.inspect('useDocker')
-            if (deprecatedUseDocker['globalValue'] !== undefined) {
+            var deprecatedUseDocker = pandocConfigurations.inspect('useDocker')?.globalValue ?? false
+            if (deprecatedUseDocker !== undefined) {
                 pandocOutputChannel.append('migrating global configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
                 vscode.window.showWarningMessage('pandoc: found deprecated value in global configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
-                pandocConfigurations.update('docker.enabled', deprecatedUseDocker['globalValue'], vscode.ConfigurationTarget.Global);
+                pandocConfigurations.update('docker.enabled', deprecatedUseDocker, vscode.ConfigurationTarget.Global);
                 pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.Global);
             }
-            if (deprecatedUseDocker['workspaceValue'] !== undefined) {
+            if (deprecatedUseDocker !== undefined) {
                 pandocOutputChannel.append('migrating workspace configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
                 vscode.window.showWarningMessage('pandoc: found deprecated value in workspace configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
-                pandocConfigurations.update('docker.enabled', deprecatedUseDocker['workspaceValue'], vscode.ConfigurationTarget.Workspace);
+                pandocConfigurations.update('docker.enabled', deprecatedUseDocker, vscode.ConfigurationTarget.Workspace);
                 pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.Workspace);
             }
-            if (deprecatedUseDocker['workspaceFolderValue'] !== undefined) {
+            if (deprecatedUseDocker !== undefined) {
                 pandocOutputChannel.append('migrating folder configuration "pandoc.useDocker" -> "pandoc.docker.enabled"\n');
                 vscode.window.showWarningMessage('pandoc: found deprecated value in folder configuration. Migrating configuration "pandoc.useDocker" -> "pandoc.docker.enabled".')
-                pandocConfigurations.update('docker.enabled', deprecatedUseDocker['workspaceFolderValue'], vscode.ConfigurationTarget.WorkspaceFolder);
+                pandocConfigurations.update('docker.enabled', deprecatedUseDocker, vscode.ConfigurationTarget.WorkspaceFolder);
                 pandocConfigurations.update('useDocker', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
             }
             var useDocker = pandocConfigurations.get('docker.enabled');


### PR DESCRIPTION
Fixes: #32 

When using this extension with a linux docker image, the file permissions
are not always correct. So there is a need to specify the docker options
to set the user-id and group-id.

This change adds the following configuration options:
* `pandoc.docker.enabled`: Replaces the existing `pandoc.useDocker`. Any
  existing configurations using the old value will be migrated over and
  the old value is deprecated. Warning will be shown when migrating.
* `pandoc.docker.options`: Set this to provide options to the `docker run`
  command. As an example you can use `--user $(id -u):$(id -g)` to set
  the correct user-id and group-id.
* `pandoc.docker.image`: Can be used to override the default docker image
  to a specified value.